### PR TITLE
adding example for Adafruit's STEMMA soil sensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 node_modules
+src/examples/basic-sample-commands/.DS_Store
+src/.DS_Store
+src/examples/.DS_Store
+.DS_Store

--- a/src/examples/adafruit-stemma-soil-sensor/device-config.js
+++ b/src/examples/adafruit-stemma-soil-sensor/device-config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  apiKey: 'YOUR_OVERLAYLIVE_API_KEY',       // Get you API key from your user dashboard : htts://my.overlay.live
+  ingest: 'ingest.epeakgears.com',
+  deviceKey: 'YOUR_CUSTOM_DEVICE_NAME'                                       // To get a device key, add a manual device to your account.
+}

--- a/src/examples/adafruit-stemma-soil-sensor/moisture-readme.tvt
+++ b/src/examples/adafruit-stemma-soil-sensor/moisture-readme.tvt
@@ -1,0 +1,11 @@
+requires CircuitPython 
+https://learn.adafruit.com/adafruit-stemma-soil-sensor-i2c-capacitive-moisture-sensor/python-circuitpython-test
+
+To install, run sudo pip3 install adafruit-circuitpython-seesaw
+Note: python 3 install is a requirement
+
+Customise your device-config.js file with your own API and device key for Overlay.live
+Install Overlay.live package
+npm install --save overlaylive-device-library
+
+Run with: node moisture.js

--- a/src/examples/adafruit-stemma-soil-sensor/moisture.js
+++ b/src/examples/adafruit-stemma-soil-sensor/moisture.js
@@ -1,0 +1,70 @@
+// Import dependencies
+// ----------------------------------------------------------------------------------------------------------------------------------------
+var OverlayLiveDevice = require('overlaylive-device-library');  // Overlay.live managed device library v2.1.1 maually
+var sensors = require('./sensor-declaration.js');               // Declaration of the sensors used bu this device
+var config = require('./device-config.js');
+
+const {PythonShell} = require('python-shell');                  // Required to read through the CircuitPython lib
+// ----------------------------------------------------------------------------------------------------------------------------------------
+
+
+// 1. Setup the manager
+console.log('Initialize manager...');
+var manager = new OverlayLiveDevice(config); // Setup the library
+console.log('Manager initialized');
+
+// 2. Describe sensors
+console.log('Declare sensors...');
+manager.declareSensors(sensors);
+console.log(manager.getSensorList().length + ' sensors declared');
+
+// 3. Connect to the Overlay.live platform
+manager.start()
+  .then(function(){
+    console.log('Start sensor readers...');
+
+    setupSoilHUM();	// call function to read from the sensor through Python.
+
+    // Start sensor watchs here
+    var refreshInterval = 1000;
+
+  })
+  .fail(function(err) {
+  console.log('Error while starting the app :');
+  console.log(err);
+});
+
+
+function setupSoilHUM(){
+	var options = {
+	    pythonPath: 'python3',
+	    mode: 'json',
+	    pythonOptions: ['-u'],
+	    scriptPath: './',
+	};
+	var Monitor = new PythonShell('moisture.py', options);
+	Monitor.on('message', parseDataToOverlayLive);
+}
+
+function parseDataToOverlayLive(message){
+	console.log(message);
+
+	if(message.Status === undefined){ //only read if there is something to read...
+
+  //loop into properties
+	for(var key in message){
+    console.log('Publish on channel ' + channel + '...');
+    var channel = key;
+    var data = message[key];
+    publishData(channel, data.toFixed(0)); //publishing readings and removing decimals
+	 }
+  }
+}
+
+function publishData(channel, data){
+	manager.publish(channel, data).then(function(){
+		console.log('Data sent on channel ' + channel);
+		}, function(err) {
+			console.log(err);
+		});
+}

--- a/src/examples/adafruit-stemma-soil-sensor/moisture.py
+++ b/src/examples/adafruit-stemma-soil-sensor/moisture.py
@@ -1,0 +1,24 @@
+import time,json,sys
+if sys.version_info[0]<3:
+	raise Exception("must be using python 3")
+
+from board import SCL, SDA
+import busio
+
+from adafruit_seesaw.seesaw import Seesaw
+
+i2c_bus = busio.I2C(SCL, SDA)
+
+ss = Seesaw(i2c_bus, addr=0x36)
+
+while True:
+    # read moisture level through capacitive touch pad
+    touch = ss.moisture_read()
+
+    # read temperature from the temperature sensor
+    temp = ss.get_temp()
+    myJson = '{"temp":'+str(temp)+',"moisture":'+str(touch)+'}'
+    parsed = json.loads(myJson)
+    print (json.dumps(parsed))
+    time.sleep(1)
+

--- a/src/examples/adafruit-stemma-soil-sensor/sensor-declaration.js
+++ b/src/examples/adafruit-stemma-soil-sensor/sensor-declaration.js
@@ -1,0 +1,23 @@
+/**
+ * Describe the managed device's sensors
+ */
+module.exports = [
+  {
+    channel: 'moisture', // [*] The channel the sensor will publish data
+    name: 'Moisture', // [*] The default sensor name
+    unit: 'M', // The sensor type (temperature, voltage, etc)
+    type: 'moisture level',
+    manufacturer: 'adafruit', // The sensor manufacturer
+    version: '1.0', // The sensor version
+    hardware: '1.0' // Additional hardware informations
+  },
+  {
+    channel: 'temp', // [*] The channel the sensor will publish data
+    name: 'Temperature', // [*] The default sensor name
+    unit: 'C', // The sensor type (temperature, voltage, etc)
+    type: 'Temperature',
+    manufacturer: 'adafruit', // The sensor manufacturer
+    version: '1.0', // The sensor version
+    hardware: '1.0' // Additional hardware informations
+  }
+];


### PR DESCRIPTION
It uses the CircuitPython lib from Adafruit. So that one needs to be installed before of course.